### PR TITLE
Optimize client by loading notes on demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,13 @@ The repository includes a minimal WebSocket relay for local testing. Start it wi
 npm run server
 ```
 
-The plugin will connect to `localhost:1234` by default. If your server uses
-TLS, a secure `wss://` connection is selected automatically, otherwise `ws://`
-is used.
+The plugin connects to `localhost:1234` by default. If your server uses TLS a
+secure `wss://` connection is chosen automatically. Documents are persisted on
+the server by default in a `yjs_data` directory next to the server script. Set
+the `YPERSISTENCE` environment variable to choose a different location or clear
+it to disable persistence entirely. Each Obsidian vault is assigned a short
+identifier derived from its path so multiple vaults can sync to the same server
+without collisions.
 
 ### Standalone Server
 
@@ -58,10 +62,11 @@ npm start
 ```
 
 The server listens on port `1234` unless the `PORT` environment variable is set.
-For HTTPS, provide file paths to your certificate and key via `SSL_CERT` and
-`SSL_KEY`. When both variables are present the server will use TLS and announce a
-`wss://` URL. The plugin automatically switches to `wss://` when it detects a
-TLS-enabled server.
+For HTTPS, provide your certificate and key via `SSL_CERT` and `SSL_KEY`. When
+both variables are present the server uses TLS and announces a `wss://` URL.
+By default documents are stored under `server/yjs_data`. Use `YPERSISTENCE` to
+specify another directory or leave it empty to disable persistence. The plugin
+automatically switches to `wss://` when it detects a TLS-enabled server.
 
 ### Roadmap
 

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,5 @@
 import { App, Plugin, PluginSettingTab, Setting, MarkdownView, TFile } from 'obsidian';
+import { createHash } from 'crypto';
 import * as Y from 'yjs';
 import { WebsocketProvider } from 'y-websocket';
 import { yCollab, yUndoManagerKeymap } from 'y-codemirror.next';
@@ -23,6 +24,8 @@ export default class ShadowLinkPlugin extends Plugin {
     settings: ShadowLinkSettings;
     doc: Y.Doc | null = null;
     provider: WebsocketProvider | null = null;
+    currentFile: TFile | null = null;
+    vaultId = '';
     collabExtensions: Extension[] = [];
     statusBarItemEl: HTMLElement | null = null;
     statusHandler?: (event: { status: string }) => void;
@@ -32,20 +35,27 @@ export default class ShadowLinkPlugin extends Plugin {
     async onload() {
         await this.loadSettings();
 
-        this.doc = new Y.Doc();
-        const url = this.resolveServerUrl(this.settings.serverUrl);
-        this.provider = new WebsocketProvider(
-            url,
-            'shadowlink',
-            this.doc
-        );
+        const basePath = (this.app.vault.adapter as any).basePath || this.app.vault.getName();
+        this.vaultId = createHash('sha256').update(basePath).digest('hex').slice(0, 8);
 
-        const color = this.colorFromId(this.provider.awareness.clientID);
-        this.provider.awareness.setLocalStateField('user', {
-            name: this.settings.username,
-            color,
-            colorLight: color + '33'
-        });
+        const url = this.resolveServerUrl(this.settings.serverUrl);
+
+        this.statusBarItemEl = this.addStatusBarItem();
+        this.statusBarItemEl.setText('ShadowLink: idle');
+
+        this.statusHandler = (event: { status: string }) => {
+            if (!this.statusBarItemEl) return;
+            switch (event.status) {
+                case 'connected':
+                    this.statusBarItemEl.setText('ShadowLink: connected');
+                    break;
+                case 'disconnected':
+                    this.statusBarItemEl.setText('ShadowLink: disconnected');
+                    break;
+                default:
+                    this.statusBarItemEl.setText('ShadowLink: ' + event.status);
+            }
+        };
 
         this.statusBarItemEl = this.addStatusBarItem();
         this.statusBarItemEl.setText('ShadowLink: connecting');
@@ -62,24 +72,18 @@ export default class ShadowLinkPlugin extends Plugin {
                     this.statusBarItemEl.setText('ShadowLink: ' + event.status);
             }
         };
-        this.provider.on('status', this.statusHandler);
-
         this.registerEditorExtension(this.collabExtensions);
-        this.registerEvent(this.app.workspace.on('file-open', this.handleFileOpen.bind(this)));
+        this.registerEvent(this.app.workspace.on('file-open', (file) => { void this.handleFileOpen(file); }));
         this.registerEvent(this.app.vault.on('delete', this.handleFileDelete.bind(this)));
         // Initialize with the currently active file if any
-        this.handleFileOpen(this.app.workspace.getActiveFile());
+        void this.handleFileOpen(this.app.workspace.getActiveFile());
 
         this.addSettingTab(new ShadowLinkSettingTab(this.app, this));
-        console.log('ShadowLink: connected to', url);
+        console.log('ShadowLink: ready, server', url);
     }
 
     onunload() {
-        if (this.provider && this.statusHandler) {
-            this.provider.off('status', this.statusHandler);
-        }
-        this.provider?.destroy();
-        this.doc?.destroy();
+        this.cleanupCurrent();
         this.statusBarItemEl?.remove();
     }
 
@@ -116,38 +120,98 @@ export default class ShadowLinkPlugin extends Plugin {
         return `hsl(${hue}, 80%, 50%)`;
     }
 
-    private handleFileDelete(file: TFile) {
-        if (!this.doc) return;
-        const ytext = this.doc.getText(file.path);
-        ytext.delete(0, ytext.length);
+    /**
+     * Yield to the event loop to keep the UI responsive.
+     */
+    private defer(): Promise<void> {
+        return new Promise(resolve => requestAnimationFrame(() => resolve()));
     }
 
-    private handleFileOpen(file: TFile | null) {
-        const view = this.app.workspace.getActiveViewOfType(MarkdownView);
-        if (!file || !view || !this.doc || !this.provider) return;
+    private docNameForFile(file: TFile): string {
+        return `${this.vaultId}/${file.path}`;
+    }
 
+    private cleanupCurrent() {
+        if (this.provider && this.statusHandler) {
+            this.provider.off('status', this.statusHandler);
+        }
+        this.provider?.destroy();
+        this.doc?.destroy();
+        this.provider = null;
+        this.doc = null;
+        this.currentText = null;
+        this.currentFile = null;
+    }
+
+    private handleFileDelete(file: TFile) {
+        if (this.currentFile && file.path === this.currentFile.path) {
+            this.cleanupCurrent();
+        }
+        // Optionally inform the server about the deletion
+        const doc = new Y.Doc();
+        const url = this.resolveServerUrl(this.settings.serverUrl);
+        const provider = new WebsocketProvider(url, this.docNameForFile(file), doc);
+        const text = doc.getText('content');
+        provider.once('sync', () => {
+            text.delete(0, text.length);
+            provider.destroy();
+            doc.destroy();
+        });
+    }
+
+    private async handleFileOpen(file: TFile | null) {
+        const view = this.app.workspace.getActiveViewOfType(MarkdownView);
+        if (!file || !view) {
+            this.cleanupCurrent();
+            return;
+        }
+
+        if (this.currentFile && this.currentFile.path === file.path) {
+            return;
+        }
+
+        this.cleanupCurrent();
+
+        const url = this.resolveServerUrl(this.settings.serverUrl);
+        this.doc = new Y.Doc();
+        this.provider = new WebsocketProvider(url, this.docNameForFile(file), this.doc);
+        this.currentFile = file;
+
+        const color = this.colorFromId(this.provider.awareness.clientID);
+        this.provider.awareness.setLocalStateField('user', {
+            name: this.settings.username,
+            color,
+            colorLight: color + '33'
+        });
+        if (this.statusHandler) {
+            this.provider.on('status', this.statusHandler);
+        }
         if (this.pendingSyncHandler) {
             this.provider.off('sync', this.pendingSyncHandler);
             this.pendingSyncHandler = undefined;
         }
 
-        const ytext = this.doc.getText(file.path);
+        const ytext = this.doc.getText('content');
         this.currentText = ytext;
 
-        const initializeText = () => {
+        const initializeText = async () => {
             if (ytext.length === 0) {
                 ytext.insert(0, view.editor.getValue());
             } else {
-                view.editor.setValue(ytext.toString());
+                const newValue = ytext.toString();
+                if (view.editor.getValue() === newValue) return;
+                await this.defer();
+                if (this.currentText !== ytext) return;
+                view.editor.setValue(newValue);
             }
         };
 
         if (this.provider.synced) {
-            initializeText();
+            await initializeText();
         } else {
-            this.pendingSyncHandler = (isSynced: boolean) => {
+            this.pendingSyncHandler = async (isSynced: boolean) => {
                 if (isSynced && this.currentText === ytext) {
-                    initializeText();
+                    await initializeText();
                     this.provider?.off('sync', this.pendingSyncHandler!);
                     this.pendingSyncHandler = undefined;
                 }
@@ -164,7 +228,12 @@ export default class ShadowLinkPlugin extends Plugin {
 
         const cm = (view.editor as any).cm as EditorView | undefined;
         if (cm) {
-            cm.dispatch({ changes: { from: 0, to: cm.state.doc.length, insert: ytext.toString() } });
+            const newValue = ytext.toString();
+            if (cm.state.doc.toString() !== newValue) {
+                await this.defer();
+                if (this.currentText !== ytext) return;
+                cm.dispatch({ changes: { from: 0, to: cm.state.doc.length, insert: newValue } });
+            }
         }
     }
 }

--- a/server.js
+++ b/server.js
@@ -1,8 +1,12 @@
 const http = require('http');
+const path = require('path');
 const WebSocket = require('ws');
-const { setupWSConnection } = require('y-websocket/bin/utils');
+const { setupWSConnection, getPersistence } = require('y-websocket/bin/utils');
 
 const port = process.env.PORT || 1234;
+if (!process.env.YPERSISTENCE) {
+    process.env.YPERSISTENCE = path.join(__dirname, 'yjs_data');
+}
 
 const server = http.createServer();
 const wss = new WebSocket.Server({ server });
@@ -12,5 +16,6 @@ wss.on('connection', (conn, req) => {
 });
 
 server.listen(port, () => {
-    console.log(`ShadowLink relay server running on ws://localhost:${port}`);
+    const persist = getPersistence() ? `with persistence at ${process.env.YPERSISTENCE}` : 'without persistence';
+    console.log(`ShadowLink relay server running on ws://localhost:${port} ${persist}`);
 });

--- a/server/server.js
+++ b/server/server.js
@@ -1,10 +1,14 @@
 const fs = require('fs');
+const path = require('path');
 const http = require('http');
 const https = require('https');
 const WebSocket = require('ws');
-const { setupWSConnection } = require('y-websocket/bin/utils');
+const { setupWSConnection, getPersistence } = require('y-websocket/bin/utils');
 
 const port = process.env.PORT || 1234;
+if (!process.env.YPERSISTENCE) {
+    process.env.YPERSISTENCE = path.join(__dirname, 'yjs_data');
+}
 const useTls = process.env.SSL_KEY && process.env.SSL_CERT;
 
 let server;
@@ -26,5 +30,8 @@ wss.on('connection', (conn, req) => {
 
 server.listen(port, () => {
     const protocol = useTls ? 'wss' : 'ws';
-    console.log(`ShadowLink relay server running on ${protocol}://localhost:${port}`);
+    const persist = getPersistence()
+        ? `with persistence at ${process.env.YPERSISTENCE}`
+        : 'without persistence';
+    console.log(`ShadowLink relay server running on ${protocol}://localhost:${port} ${persist}`);
 });


### PR DESCRIPTION
## Summary
- refactor plugin to create a Yjs document per opened note
- clean up previous sessions when switching notes
- notify server about deletions
- log persistence status for relay servers
- default relay persistence to `yjs_data` and avoid vault collisions
- document server persistence in README

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6848360d70bc8332a4f86b0e56e4726b