### PR TITLE
Fix duplicate status bar items

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -43,23 +43,6 @@ export default class ShadowLinkPlugin extends Plugin {
         const url = this.resolveServerUrl(this.settings.serverUrl);
 
         this.statusBarItemEl = this.addStatusBarItem();
-        this.statusBarItemEl.setText('ShadowLink: idle');
-
-        this.statusHandler = (event: { status: string }) => {
-            if (!this.statusBarItemEl) return;
-            switch (event.status) {
-                case 'connected':
-                    this.statusBarItemEl.setText('ShadowLink: connected');
-                    break;
-                case 'disconnected':
-                    this.statusBarItemEl.setText('ShadowLink: disconnected');
-                    break;
-                default:
-                    this.statusBarItemEl.setText('ShadowLink: ' + event.status);
-            }
-        };
-
-        this.statusBarItemEl = this.addStatusBarItem();
         this.statusBarItemEl.setText('ShadowLink: connecting');
         this.statusHandler = (event: { status: string }) => {
             if (!this.statusBarItemEl) return;


### PR DESCRIPTION
## Summary
- avoid duplicate `addStatusBarItem` calls in `onload`
- start status bar at `ShadowLink: connecting`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684845e08fe08332af8da4e8a0c96732